### PR TITLE
Update construct-cdl-python-lambda-function.ts - fix merge conflict

### DIFF
--- a/lib/constructs/construct-cdl-python-lambda-function/construct-cdl-python-lambda-function.ts
+++ b/lib/constructs/construct-cdl-python-lambda-function/construct-cdl-python-lambda-function.ts
@@ -96,11 +96,7 @@ export class CdlPythonLambda extends lambda.Function {
        * Creates a Python Lambda Function with FIFO dead letter queue, x86 architecture,
        * and X-ray tracing.
        */
-<<<<<<< HEAD
       runtime: props.runtime ? props.runtime : lambda.Runtime.PYTHON_3_10,
-=======
-      runtime: props.runtime,
->>>>>>> main
       code: props.code,
       handler: props.handler,
       layers: props.layers,


### PR DESCRIPTION
When running npm run build we get this error:
```
lib/constructs/construct-cdl-python-lambda-function/construct-cdl-python-lambda-function.ts:99:1 - error TS1185: Merge conflict marker encountered.
99 <<<<<<< HEAD
lib/constructs/construct-cdl-python-lambda-function/construct-cdl-python-lambda-function.ts:101:1 - error TS1185: Merge conflict marker encountered.
101 =======
lib/constructs/construct-cdl-python-lambda-function/construct-cdl-python-lambda-function.ts:103:1 - error TS1185: Merge conflict marker encountered.
103 >>>>>>> main
Found 3 errors in the same file, starting at: lib/constructs/construct-cdl-python-lambda-function/construct-cdl-python-lambda-function.ts:99
```
JFYI: this was introduced here: https://github.com/aws-solutions-library-samples/guidance-for-carbon-data-lake-on-aws/commit/920e2a29c3c614f6011487e84a2a72ae666a42d1.

This PR fixes this issue.